### PR TITLE
Fix: use __dirname to find transform files (refs #2)

### DIFF
--- a/bin/eslint-transforms.js
+++ b/bin/eslint-transforms.js
@@ -3,6 +3,7 @@
 "use strict";
 
 var nodeCLI = require("shelljs-nodecli");
+var path = require("path");
 
 var argv = process.argv.slice(2);
 var args = argv.slice(1);
@@ -10,6 +11,6 @@ var transform = argv[0];
 
 nodeCLI.exec(
     "jscodeshift",
-    "-t", "./lib/" + transform + "/" + transform + ".js",
+    "-t", path.resolve(__dirname, "../lib/" + transform + "/" + transform + ".js"),
     args.join(" ")
 );

--- a/bin/eslint-transforms.js
+++ b/bin/eslint-transforms.js
@@ -2,15 +2,44 @@
 
 "use strict";
 
-var nodeCLI = require("shelljs-nodecli");
+var execSync = require("child_process").execSync;
+var objectAssign = require("object-assign");
 var path = require("path");
 
 var argv = process.argv.slice(2);
 var args = argv.slice(1);
 var transform = argv[0];
 
-nodeCLI.exec(
+/**
+ * Add possible node_modules/.bin paths to env and run the command passed in.
+ *
+ * @param {string} cmd The command to run
+ * @returns {void}
+ */
+function execWithNodeModules(cmd) {
+    var SEPARATOR = process.platform === "win32" ? ";" : ":",
+        env = objectAssign({}, process.env);
+
+    env.PATH = [
+        // Covers case when npm flattens dependencies and the jscodeshift bin will be directly under the root
+        // node_modules folder
+        path.resolve("./node_modules/.bin"),
+        // Covers case when dependencies are not flattened and the jscodeshift bin can be found under the
+        // node_modules folder of our package
+        path.resolve(__dirname, "../node_modules/.bin"),
+        env.PATH
+    ].join(SEPARATOR);
+
+    execSync(cmd, {
+        env: env,
+        cwd: process.cwd(),
+        stdio: "inherit"
+    });
+}
+
+execWithNodeModules([
     "jscodeshift",
-    "-t", path.resolve(__dirname, "../lib/" + transform + "/" + transform + ".js"),
+    "-t",
+    path.resolve(__dirname, "../lib/" + transform + "/" + transform + ".js"),
     args.join(" ")
-);
+].join(" "));

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "jscodeshift": "^0.3.20",
-    "shelljs-nodecli": "^0.1.1"
+    "object-assign": "^4.1.0"
   },
   "keywords": [
     "javascript",


### PR DESCRIPTION
The executable was not using `__dirname` to look for the transforms before, which was causing it to error out when installed through npm (See #2). This PR should fix the issue.