### PR TITLE
Chore: ensure consistent linebreaks when testing transforms

### DIFF
--- a/tests/lib/new-rule-format/new-rule-format.js
+++ b/tests/lib/new-rule-format/new-rule-format.js
@@ -9,10 +9,24 @@
 
 var jscodeshift = require("jscodeshift");
 var fs = require("fs");
+var os = require("os");
 var path = require("path");
 var expect = require("chai").expect;
 
 var newRuleFormatTransform = require("../../../lib/new-rule-format/new-rule-format");
+
+/**
+ * Returns a new string with all the EOL markers from the string passed in
+ * replaced with the Operating System specific EOL marker.
+ * Useful for guaranteeing two transform outputs have the same EOL marker format.
+ *
+ * @param {string} input - the string which will have its EOL markers replaced
+ * @returns {string} a new string with all EOL markers replaced
+ * @private
+ */
+function normalizeLineEndngs(input) {
+    return input.replace(/(\r\n|\n|\r)/gm, os.EOL);
+}
 
 /**
  * Run a transform against a fixture file and compare results with expected output.
@@ -21,8 +35,9 @@ var newRuleFormatTransform = require("../../../lib/new-rule-format/new-rule-form
  * `tests/fixtures/` folder.
  *
  * @param {Function} transform - transform to test against
- * @param {String} transformFixturePrefix - prefix of fixture files
+ * @param {string} transformFixturePrefix - prefix of fixture files
  * @returns {void}
+ * @private
  */
 function testTransformWithFixture(transform, transformFixturePrefix) {
     var fixtureDir = path.join(__dirname, "../../fixtures/lib/new-rule-format");
@@ -42,9 +57,9 @@ function testTransformWithFixture(transform, transformFixturePrefix) {
         );
 
         expect(
-            (output || "").trim()
+            normalizeLineEndngs((output || "").trim())
         ).to.equal(
-            expectedOutput.trim()
+            normalizeLineEndngs(expectedOutput.trim())
         );
     });
 }
@@ -57,8 +72,9 @@ function testTransformWithFixture(transform, transformFixturePrefix) {
  * `tests/fixtures/` folder.
  *
  * @param {Function} transform - transform to test against
- * @param {String[]} fixtures - list of fixture prefixes
+ * @param {string[]} fixtures - list of fixture prefixes
  * @returns {void}
+ * @private
  */
 function testTransformWithFixtures(transform, fixtures) {
     return fixtures.forEach(function(fixture) {


### PR DESCRIPTION
**What issue does this pull request address?**
Tests were failing in windows because jscodeshift transforms all line breaks of the input file into the OS-specific line break format. This caused the tests to compare the transform output (CRLF format) against the "expected result" fixture (LF format), which would always fail.

**What changes did you make? (Give an overview)**
I made it so the tests now ensure all output being compared is using the same line break format, so the problem never happens again.

**Is there anything you'd like reviewers to focus on?**
* Is the name of the new helper method okay?
* Is this a `Chore` or a `Fix`? I went with Chore as it's not a user-facing change.
