### PR TITLE
Upgrade: eslint-release@^0.10.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "chai": "^3.5.0",
     "eslint": "^2.9.0",
     "eslint-config-eslint": "^3.0.0",
-    "eslint-release": "^0.9.2",
+    "eslint-release": "^0.10.1",
     "mocha": "^2.5.3"
   },
   "dependencies": {


### PR DESCRIPTION
Ensures that the eslint-transforms release will automatically push to GitHub.