### PR TITLE
chore: standardize npm script names

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,13 +17,13 @@
   ],
   "scripts": {
     "lint": "eslint .",
-    "test": "mocha ./tests/lib/**/*.js",
     "new-rule-format": "node ./bin/eslint-transforms.js -t ./lib/new-rule-format/new-rule-format.js",
-    "generate-release": "eslint-generate-release",
-    "generate-alpharelease": "eslint-generate-prerelease alpha",
-    "generate-betarelease": "eslint-generate-prerelease beta",
-    "generate-rcrelease": "eslint-generate-prerelease rc",
-    "publish-release": "eslint-publish-release"
+    "release:generate:latest": "eslint-generate-release",
+    "release:generate:alpha": "eslint-generate-prerelease alpha",
+    "release:generate:beta": "eslint-generate-prerelease beta",
+    "release:generate:rc": "eslint-generate-prerelease rc",
+    "release:publish": "eslint-publish-release",
+    "test": "mocha ./tests/lib/**/*.js"
   },
   "devDependencies": {
     "chai": "^3.5.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "lib"
   ],
   "scripts": {
-    "build:new-rule-format": "node ./bin/eslint-transforms.js -t ./lib/new-rule-format/new-rule-format.js",
     "lint": "eslint .",
     "release:generate:latest": "eslint-generate-release",
     "release:generate:alpha": "eslint-generate-prerelease alpha",

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "lib"
   ],
   "scripts": {
+    "build:new-rule-format": "node ./bin/eslint-transforms.js -t ./lib/new-rule-format/new-rule-format.js",
     "lint": "eslint .",
-    "new-rule-format": "node ./bin/eslint-transforms.js -t ./lib/new-rule-format/new-rule-format.js",
     "release:generate:latest": "eslint-generate-release",
     "release:generate:alpha": "eslint-generate-prerelease alpha",
     "release:generate:beta": "eslint-generate-prerelease beta",


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request?

Refers https://github.com/eslint/eslint/issues/14827
<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

This updates the names of the scripts in package.json to be consistent with the [new standard](https://eslint.org/docs/latest/contribute/package-json-conventions).


#### Is there anything you'd like reviewers to focus on?
We may need to update the `release` related scripts on Jenkins before merging this PR.
<!-- markdownlint-disable-file MD004 -->
