### PR TITLE
chore: use eslint-config-eslint@9.0.0

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,13 +1,13 @@
 "use strict";
 
-const eslintConfig = require("eslint-config-eslint");
+const eslintConfigESLintCJS = require("eslint-config-eslint/cjs");
 const globals = require("globals");
 
 module.exports = [
     {
         ignores: ["tests/fixtures/"]
     },
-    ...eslintConfig,
+    ...eslintConfigESLintCJS,
     {
         files: ["tests/**/*"],
         languageOptions: {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "devDependencies": {
     "chai": "^3.5.0",
     "eslint": "^8.45.0",
-    "eslint-config-eslint": "^8.0.0",
+    "eslint-config-eslint": "^9.0.0",
     "eslint-release": "^1.0.0",
     "globals": "^13.20.0",
     "mocha": "^2.5.3"


### PR DESCRIPTION
Switches to eslint-config-eslint@9.0.0.

I checked with `--print-config` that the configuration for `.js` files is the same as before this change, except for `settings.jsdoc.mode` field that was added in https://github.com/eslint/eslint/pull/17338.