### PR TITLE
ci: run tests in Node.js 22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,9 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 'lts/*'
       - name: Install dependencies
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node: [21.x, 20.x, 19.x, 18.x, 17.x, 16.x, 14.x, 12.x, "12.22.0"]
+        node: [22.x, 21.x, 20.x, 19.x, 18.x, 17.x, 16.x, 14.x, 12.x, "12.22.0"]
         include:
         - os: windows-latest
           node: "lts/*"
@@ -33,8 +33,8 @@ jobs:
           node: "lts/*"
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-node@v3
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node }}
     - name: Install dependencies

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -29,9 +29,9 @@ jobs:
               { "type": "refactor", "section": "Chores", "hidden": false },
               { "type": "test", "section": "Chores", "hidden": false }
             ]
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         if: ${{ steps.release.outputs.release_created }}
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: lts/*
           registry-url: https://registry.npmjs.org


### PR DESCRIPTION
Updates the CI workflow to run tests in Node.js 22.

Also upgrades `actions/checkout` and `actions/setup-node` to v4.