### PR TITLE
docs: update Node.js version requirement in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ESLint Transforms
 
 A collection of jscodeshift transforms to help upgrade ESLint rules to new versions of [ESLint](https://github.com/eslint/eslint).
-Supports [Node.js](https://nodejs.org) version 4 or above.
+Supports [Node.js](https://nodejs.org) version 20 or above.
 
 ## Installation
 
@@ -41,11 +41,11 @@ to the new format, introduced in ESLint 2.10.0:
 
 ```javascript
 module.exports = {
- meta: {
-     docs: {},
-     schema: []
- },
- create: function(context) { ... }
+    meta: {
+        docs: {},
+        schema: []
+    },
+    create: function(context) { ... }
 };
 ```
 

--- a/lib/v9-rule-migration/v9-rule-migration.js
+++ b/lib/v9-rule-migration/v9-rule-migration.js
@@ -10,6 +10,7 @@
 //------------------------------------------------------------------------------
 // Requirements
 //------------------------------------------------------------------------------
+
 const path = require("node:path");
 
 //------------------------------------------------------------------------------
@@ -93,10 +94,9 @@ function getParentObjectMethod(nodePath) {
 /**
  * Transforms an ESLint rule from the old format to the new format.
  * @param {Object} fileInfo holds information about the currently processed file.
- * * @param {Object} api holds the jscodeshift API
+ * @param {Object} api holds the jscodeshift API
  * @returns {string} the new source code, after being transformed.
  */
-
 module.exports = function(fileInfo, api) {
     const j = api.jscodeshift;
     const root = j(fileInfo.source);


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

## Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

## What is the purpose of this pull request?

In this PR, I've updated the Node.js version requirement in `README.md`.

Based on the CHANGELOG and the `engines.node` field in `package.json`, it looks like Node.js 20 is the supported version.

https://github.com/eslint/eslint-transforms/blob/6e46bf6f2fb48c8434bb5e689d1f04fe0a677fc2/CHANGELOG.md?plain=1#L8

https://github.com/eslint/eslint-transforms/blob/6e46bf6f2fb48c8434bb5e689d1f04fe0a677fc2/package.json#L8-L10

## What changes did you make? (Give an overview)

In this PR, I've updated the Node.js version requirement in `README.md`.

## Related Issues

N/A

<!-- include tags like "fixes #123" or "refs #123" -->

## Is there anything you'd like reviewers to focus on?

I've also corrected some formatting issues throughout the codebase.

Since `.editorconfig` specifies an indent size of 4, I've updated the code to match.

https://github.com/eslint/eslint-transforms/blob/6e46bf6f2fb48c8434bb5e689d1f04fe0a677fc2/.editorconfig#L5
